### PR TITLE
fix git remote add command in the README

### DIFF
--- a/PolarStereoPlot_Lesson/cartopydemo.ipynb
+++ b/PolarStereoPlot_Lesson/cartopydemo.ipynb
@@ -175,7 +175,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7ff3413a3470>"
+       "<matplotlib.collections.QuadMesh at 0x7f611bda4438>"
       ]
      },
      "execution_count": 6,

--- a/README
+++ b/README
@@ -24,13 +24,13 @@ At some point if you'd like to get the latest stuff from this master
 repo (it's a good idea make sure your own repository is up to date
 first), type the following:
 
-> git remote add upstream https://github.com/cmbitz/HackyHours
+> git remote add upstream https://github.com/cmbitz/HackyHours.git
 > git fetch upstream
 > git merge upstream/master
 
 or we think equivalently 
 
-> git remote add upstream https://github.com/cmbitz/HackyHours
+> git remote add upstream https://github.com/cmbitz/HackyHours.git
 > git pull upstream master
 
 


### PR DESCRIPTION
The git remote add upstream commands needed ".git" on the end of the URLs.